### PR TITLE
Avoid ${rootProject.projectDir} interpolation in changelog config

### DIFF
--- a/oniguruma-jni/build.gradle.kts
+++ b/oniguruma-jni/build.gradle.kts
@@ -26,7 +26,7 @@ github {
 changelog {
     githubUser = github.user
     futureVersionTag = project.version.toString()
-    outputFile = file("${rootProject.projectDir}/CHANGELOG.md")
+    outputFile = rootProject.file("CHANGELOG.md")
 }
 
 repositories {


### PR DESCRIPTION
Dependabot's Gradle updater crashes (TypeError: Passed nil into T.must) when resolving rootProject.* properties in a repo without a root build file, which silently blocked all dependency updates declared in this build script. Use rootProject.file() instead, which resolves to the same path.