### PR TITLE
Drop UTF-8 validation and the per-match Vec from the JNI binding

### DIFF
--- a/oniguruma-jni/CHANGELOG.md
+++ b/oniguruma-jni/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `createRegex` and `createString` no longer validate that their input is UTF-8; malformed bytes
+  now reach oniguruma instead of raising a `RuntimeException`. Valid UTF-8 was always the
+  documented expectation, and the `oniguruma-ffm` binding never validated. Callers that relied on
+  the error must validate before calling.
+
+### Performance
+
+- `createString` skips the UTF-8 validation pass, leaving a single copy into native memory.
+- Match offsets are collected into a reused per-thread buffer instead of a freshly allocated
+  vector on every match.
+
 ## [2.0.0] - 2026-06-18
 
 Reimplemented in Java and renamed. Every consumer has to touch imports to upgrade.

--- a/oniguruma-jni/native/src/lib.rs
+++ b/oniguruma-jni/native/src/lib.rs
@@ -25,7 +25,7 @@ use std::{
     ffi::c_void,
     panic::{catch_unwind, RefUnwindSafe},
     ptr, slice,
-    str::{self, Utf8Error},
+    str,
     sync::OnceLock,
 };
 
@@ -44,9 +44,10 @@ pub unsafe extern "system" fn JNI_OnLoad(raw_vm: *mut jni::sys::JavaVM, _: *mut 
     jni::sys::JNI_VERSION_1_8
 }
 
-// Reuse a Region per thread to avoid a malloc/free on every match call.
+// Reuse a Region and the offsets buffer per thread to avoid a malloc/free on every match call.
 thread_local! {
     static REGION: RefCell<Region> = RefCell::new(Region::new());
+    static OFFSETS: RefCell<Vec<i32>> = RefCell::new(Vec::new());
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -56,9 +57,6 @@ enum Error {
 
     #[error("Oniguruma Error: {0}")]
     Oniguruma(#[from] onig::Error),
-
-    #[error("Unable to read UTF8 string: {0}")]
-    Utf8(#[from] Utf8Error),
 
     #[error("String or pattern is null")]
     NullPatternOrString,
@@ -154,7 +152,10 @@ fn create_regex(env: &JNIEnv, pattern: jbyteArray) -> Result<jlong> {
     }
     let p = unsafe { JByteArray::from_raw(pattern) };
     let byte_array: Vec<u8> = env.convert_byte_array(p)?;
-    let pattern_str = str::from_utf8(&byte_array)?;
+    // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createRegex, matching
+    // the FFM binding, which hands the bytes to oniguruma without validating either. The bytes
+    // go straight through to onig_new; nothing on the Rust side inspects them as text.
+    let pattern_str = unsafe { str::from_utf8_unchecked(&byte_array) };
     let regex = Regex::with_options(
         pattern_str,
         RegexOptions::REGEX_OPTION_CAPTURE_GROUP,
@@ -197,19 +198,21 @@ fn match_pattern(
             Some(&mut *region),
         );
         if matched.is_some() {
-            let mut iterator = region.iter();
-
-            // Constructing a Vec containing all the start and end offsets one after the other.
-            //
-            // Region iterator can return None, but we still need to iterate region.len() times
-            // not matter what. This is not ideiomatic API, but oh well.
-            let offsets = (0..region.len())
-                .map(|_| iterator.next())
-                .map(|i| i.map(|(s, e)| (s as i32, e as i32)))
-                .map(|i| i.unwrap_or((-1, -1)))
-                .flat_map(|(s, e)| [s, e])
-                .collect::<Vec<_>>();
-            Ok(create_jni_int_array(env, &offsets)?.into_raw())
+            // Filling a reused buffer with all the start and end offsets one after the other;
+            // unmatched groups report (-1, -1).
+            OFFSETS.with(|o| {
+                let mut offsets = o.borrow_mut();
+                offsets.clear();
+                for i in 0..region.len() {
+                    let (s, e) = region
+                        .pos(i)
+                        .map(|(s, e)| (s as i32, e as i32))
+                        .unwrap_or((-1, -1));
+                    offsets.push(s);
+                    offsets.push(e);
+                }
+                Ok(create_jni_int_array(env, offsets.as_slice())?.into_raw())
+            })
         } else {
             Ok(ptr::null_mut())
         }
@@ -225,7 +228,12 @@ fn create_string(env: &mut JNIEnv, utf8: jbyteArray) -> Result<jlong> {
             // Critical: pins the Java heap object without copying (GC is suspended for duration).
             let elements = env.get_array_elements_critical(&p, ReleaseMode::NoCopyBack)?;
             let slice = slice::from_raw_parts(elements.as_ptr() as *const u8, elements.len());
-            let str = str::from_utf8(slice)?.to_string();
+            // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createString,
+            // matching the FFM binding, which copies the bytes into native memory without
+            // validating either. The bytes go straight through to onig_search; nothing on the
+            // Rust side inspects them as text. Skipping validation keeps createString a single
+            // copy, which is most of its cost for large texts.
+            let str = String::from_utf8_unchecked(slice.to_vec());
             drop(elements); // Release critical section before any further JNI calls.
             Ok(Box::into_raw(Box::<String>::new(str)) as jlong)
         }

--- a/oniguruma-jni/src/main/java/me/zolotov/oniguruma/jni/Oniguruma.java
+++ b/oniguruma-jni/src/main/java/me/zolotov/oniguruma/jni/Oniguruma.java
@@ -24,10 +24,20 @@ public final class Oniguruma {
             boolean matchBeginString
     );
 
+    /**
+     * Compiles a pattern. {@code pattern} must be valid UTF-8: the bytes are handed to oniguruma
+     * without validation, and malformed input makes matching against the resulting regex
+     * undefined. This matches the {@code oniguruma-ffm} binding's contract.
+     */
     public native long createRegex(byte[] pattern);
 
     public native void freeRegex(long regexPtr);
 
+    /**
+     * Copies a subject string into native memory. {@code utf8Content} must be valid UTF-8: the
+     * bytes are handed to oniguruma without validation, and matching against malformed input is
+     * undefined. This matches the {@code oniguruma-ffm} binding's contract.
+     */
     public native long createString(byte[] utf8Content);
 
     public native void freeString(long textPtr);


### PR DESCRIPTION
createRegex and createString validated their input as UTF-8 before handing it to oniguruma. The FFM binding never did: valid UTF-8 is the caller contract there, so the JNI binding was paying a per-byte validation pass -- most of createString's cost after the copy itself -- for a rejection the sibling binding does not offer. Both native methods now document the contract and pass the bytes through unchecked, and the Utf8 error variant is gone.

Match offsets are now collected into a reused per-thread buffer next to the reused Region instead of a freshly allocated Vec per match. The manual iterator dance (next() exactly len() times so an unmatched group's None maps to (-1, -1) instead of ending iteration) becomes a plain indexed loop over Region::pos, which is what the iterator's next() delegates to anyway.