### PR TITLE
Stop clearing the reused region before every JNI search

### DIFF
--- a/oniguruma-jni/native/src/lib.rs
+++ b/oniguruma-jni/native/src/lib.rs
@@ -188,7 +188,9 @@ fn match_pattern(
 
     REGION.with(|r| {
         let mut region = r.borrow_mut();
-        region.clear();
+        // The reused region needs no clearing before the search: onig_search resize-clears a
+        // non-null region unconditionally on entry, on both the match and the mismatch paths
+        // (oniguruma 6.9.8, as bundled by onig_sys 69.8.1: regexec.c, search_in_range).
         let matched = regex.search_with_options(
             str,
             byte_offset as usize,


### PR DESCRIPTION
onig_search resize-clears a non-null region unconditionally on entry, on both the match and the mismatch paths, so the reused thread-local region never carries stale state into a result. Verified in the oniguruma sources bundled by onig_sys 69.8.1 (6.9.8, regexec.c search_in_range) - the same check that removed the equivalent onig_region_clear downcall from the FFM binding.