### PR TITLE
Reject out-of-range byteOffset in the JNI match

### DIFF
--- a/oniguruma-jni/CHANGELOG.md
+++ b/oniguruma-jni/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+- `match` now rejects a `byteOffset` outside `[0, length]` with an `IllegalArgumentException`,
+  matching the `oniguruma-ffm` binding. Previously a negative offset silently reported no match
+  and a too-large offset raised a generic `RuntimeException` from the native layer.
 - `createRegex` and `createString` no longer validate that their input is UTF-8; malformed bytes
   now reach oniguruma instead of raising a `RuntimeException`. Valid UTF-8 was always the
   documented expectation, and the `oniguruma-ffm` binding never validated. Callers that relied on

--- a/oniguruma-jni/native/src/lib.rs
+++ b/oniguruma-jni/native/src/lib.rs
@@ -61,6 +61,9 @@ enum Error {
     #[error("String or pattern is null")]
     NullPatternOrString,
 
+    #[error("byteOffset {offset} out of range [0, {length}]")]
+    ByteOffsetOutOfRange { offset: i32, length: usize },
+
     #[error("Panic happened: {0}")]
     Panic(String),
 
@@ -179,6 +182,16 @@ fn match_pattern(
     let regex = unsafe { &*(regex_ptr as *const Regex) };
     let str = unsafe { &*(string_ptr as *mut String) };
 
+    // The onig crate offsets the string pointer by `from` before it bounds-checks, so an
+    // out-of-range offset is out-of-bounds pointer arithmetic (UB) before it is anything else.
+    // Reject it here instead, with the same exception the FFM binding throws.
+    if byte_offset < 0 || byte_offset as usize > str.len() {
+        return Err(Error::ByteOffsetOutOfRange {
+            offset: byte_offset,
+            length: str.len(),
+        });
+    }
+
     let mut options = SearchOptions::SEARCH_OPTION_NONE;
     if match_begin_position == 0 {
         options |= unsafe { SearchOptions::from_bits_unchecked(ONIG_OPTION_NOT_BEGIN_POSITION) };
@@ -256,16 +269,24 @@ impl<T> ToJavaException<T> for Result<T> {
     fn propagate_exception(self, mut env: JNIEnv) -> Option<T> {
         match self {
             Ok(r) => Some(r),
-            Err(jni_error) => {
+            Err(error) => {
                 if !env.exception_check().unwrap() {
                     // Only throw if there is no pending exception yet.
-                    // Use the cached GlobalRef to avoid a class lookup on the error path.
-                    match RUNTIME_EXCEPTION_CLASS.get() {
-                        Some(cls) => env.throw_new(cls, jni_error.to_string()).unwrap(),
-                        None => {
-                            let class = env.find_class("java/lang/RuntimeException").unwrap();
-                            env.throw_new(class, jni_error.to_string()).unwrap();
+                    match &error {
+                        // Caller errors surface as IllegalArgumentException, matching the FFM
+                        // binding. This path is rare enough that the class lookup is fine.
+                        Error::ByteOffsetOutOfRange { .. } => {
+                            let class = env.find_class("java/lang/IllegalArgumentException").unwrap();
+                            env.throw_new(class, error.to_string()).unwrap();
                         }
+                        // Use the cached GlobalRef to avoid a class lookup on every throw.
+                        _ => match RUNTIME_EXCEPTION_CLASS.get() {
+                            Some(cls) => env.throw_new(cls, error.to_string()).unwrap(),
+                            None => {
+                                let class = env.find_class("java/lang/RuntimeException").unwrap();
+                                env.throw_new(class, error.to_string()).unwrap();
+                            }
+                        },
                     }
                 }
                 None

--- a/oniguruma-jni/src/main/java/me/zolotov/oniguruma/jni/Oniguruma.java
+++ b/oniguruma-jni/src/main/java/me/zolotov/oniguruma/jni/Oniguruma.java
@@ -16,6 +16,13 @@ public final class Oniguruma {
         return new Oniguruma();
     }
 
+    /**
+     * Searches {@code textPtr} from {@code byteOffset}.
+     *
+     * @throws IllegalArgumentException if {@code byteOffset} is outside {@code [0, length]} of the
+     *                                  string behind {@code textPtr}. This matches the
+     *                                  {@code oniguruma-ffm} binding's contract.
+     */
     public native int[] match(
             long regexPtr,
             long textPtr,

--- a/oniguruma-jni/src/test/java/me/zolotov/oniguruma/jni/OnigurumaTest.java
+++ b/oniguruma-jni/src/test/java/me/zolotov/oniguruma/jni/OnigurumaTest.java
@@ -8,8 +8,25 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OnigurumaTest {
+    @Test
+    void matchRejectsByteOffsetOutOfRange() {
+        Oniguruma oniguruma = Oniguruma.createFromResources();
+        long regexPtr = oniguruma.createRegex("a".getBytes(StandardCharsets.UTF_8));
+        long textPtr = oniguruma.createString("abc".getBytes(StandardCharsets.UTF_8));
+        try {
+            assertThrows(IllegalArgumentException.class,
+                    () -> oniguruma.match(regexPtr, textPtr, 4, true, true));
+            assertThrows(IllegalArgumentException.class,
+                    () -> oniguruma.match(regexPtr, textPtr, -1, true, true));
+        } finally {
+            oniguruma.freeString(textPtr);
+            oniguruma.freeRegex(regexPtr);
+        }
+    }
+
     @Test
     void matching() {
         withMatcher("[0-9]+", matcher ->


### PR DESCRIPTION
Validate the offset on the native side and throw the same IllegalArgumentException as oniguruma-ffm, so the two bindings agree on caller errors.