### PR TITLE
Migrate to jni 0.22.4 and bump Rust to 1.85.0

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_VERSION: 1.84.1
+  RUST_VERSION: 1.85.0
   BENCHMARK_PAGES_URL: ${{ format('https://{0}.github.io/{1}', github.repository_owner, github.event.repository.name) }}
 
 jobs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
         type: string
 
 env:
-  RUST_VERSION: 1.84.1
+  RUST_VERSION: 1.85.0
 
 jobs:
   build-native-linux:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_VERSION: 1.84.1
+  RUST_VERSION: 1.85.0
 
 jobs:
   test:

--- a/oniguruma-jni/native/Cargo.lock
+++ b/oniguruma-jni/native/Cargo.lock
@@ -24,12 +24,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,25 +41,52 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
+ "jni-macros",
  "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "libc"
@@ -120,7 +141,7 @@ dependencies = [
  "jni",
  "onig",
  "onig_sys",
- "thiserror 2.0.19",
+ "thiserror",
 ]
 
 [[package]]
@@ -148,6 +169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,10 +187,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "syn"
@@ -186,31 +238,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.19",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -246,17 +278,14 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.45.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -264,22 +293,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -288,21 +302,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -312,21 +320,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -342,21 +338,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -366,21 +350,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/oniguruma-jni/native/Cargo.toml
+++ b/oniguruma-jni/native/Cargo.toml
@@ -10,7 +10,7 @@ name = "oniguruma_jni"
 [dependencies]
 onig = { version = "6.5", default-features = false }
 onig_sys = { version = "69.9", default-features = false }
-jni = { version = "0.21.1" }
+jni = { version = "0.22.4" }
 thiserror = "2.0.11"
 
 [profile.release]

--- a/oniguruma-jni/native/rust-toolchain
+++ b/oniguruma-jni/native/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"

--- a/oniguruma-jni/native/src/lib.rs
+++ b/oniguruma-jni/native/src/lib.rs
@@ -9,37 +9,38 @@
 //! 3. the method name is separated from the class name with an underscore
 //!
 //! So, for example `java.lang.System::gc()` becomes `Java_java_lang_System_gc`.
+//!
+//! Since jni 0.22 the environment a native method receives is an `EnvUnowned`, which carries no
+//! JNI methods of its own; `EnvUnowned::with_env` upgrades it to a `&mut Env` for the duration of
+//! a closure and catches any panic. Errors and panics are turned into Java exceptions by the
+//! [`ThrowMapped`] error policy.
 
 use jni::{
-    objects::{GlobalRef, JByteArray, JClass, JPrimitiveArray, ReleaseMode},
-    sys::{jboolean, jbyteArray, jint, jintArray, jlong},
-    JavaVM, JNIEnv,
+    errors::ErrorPolicy,
+    jni_str,
+    objects::{Global, JByteArray, JClass, JIntArray, ReleaseMode},
+    refs::Reference,
+    strings::JNIString,
+    sys::{jboolean, jint, jlong},
+    Env, EnvUnowned,
 };
 use onig::Regex;
 use onig::{RegexOptions, Region, SearchOptions, Syntax};
 use onig_sys::{ONIG_OPTION_NOT_BEGIN_POSITION, ONIG_OPTION_NOT_BEGIN_STRING};
-use std::{
-    any::Any,
-    cell::RefCell,
-    ffi::c_void,
-    panic::{catch_unwind, RefUnwindSafe},
-    ptr, slice,
-    str,
-    sync::OnceLock,
-};
+use std::{any::Any, cell::RefCell, ffi::c_void, slice, str, sync::OnceLock};
 
 type Result<T> = std::result::Result<T, Error>;
 
-// Cache a GlobalRef to RuntimeException so the error path avoids a class lookup on every throw.
-static RUNTIME_EXCEPTION_CLASS: OnceLock<GlobalRef> = OnceLock::new();
+// Cache a Global to RuntimeException so the error path avoids a class lookup on every throw.
+// Filled on the first throw rather than in JNI_OnLoad: an `Env` can only be borrowed from a
+// thread attachment now, and there is no attachment to borrow from during library load.
+static RUNTIME_EXCEPTION_CLASS: OnceLock<Global<JClass<'static>>> = OnceLock::new();
 
 #[no_mangle]
 #[allow(non_snake_case)]
-pub unsafe extern "system" fn JNI_OnLoad(raw_vm: *mut jni::sys::JavaVM, _: *mut c_void) -> jint {
-    let vm = JavaVM::from_raw(raw_vm).unwrap();
-    let mut env: JNIEnv = vm.get_env().unwrap();
-    let cls = env.find_class("java/lang/RuntimeException").unwrap();
-    RUNTIME_EXCEPTION_CLASS.set(env.new_global_ref(cls).unwrap()).ok();
+pub extern "system" fn JNI_OnLoad(_: *mut jni::sys::JavaVM, _: *mut c_void) -> jint {
+    // jni initializes itself on the first `EnvUnowned::with_env`, so all this hook has to do is
+    // report the JNI version the library needs.
     jni::sys::JNI_VERSION_1_8
 }
 
@@ -65,37 +66,33 @@ enum Error {
     #[error("byteOffset {offset} out of range [0, {length}]")]
     ByteOffsetOutOfRange { offset: i32, length: usize },
 
-    #[error("Panic happened: {0}")]
-    Panic(String),
-
     #[error("Null Pointer")]
     NullPointer,
 }
 
 #[no_mangle]
-pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_createRegex(
-    env: JNIEnv,
-    _: JClass,
-    pattern: jbyteArray,
+pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_createRegex<'caller>(
+    mut env: EnvUnowned<'caller>,
+    _: JClass<'caller>,
+    pattern: JByteArray<'caller>,
 ) -> jlong {
-    try_catch(|| create_regex(&env, pattern))
-        .propagate_exception(env)
-        .unwrap_or_default()
+    env.with_env(|env| create_regex(env, &pattern))
+        .resolve::<ThrowMapped>()
 }
 
 #[no_mangle]
-pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_match(
-    env: JNIEnv,
-    _: JClass,
+pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_match<'caller>(
+    mut env: EnvUnowned<'caller>,
+    _: JClass<'caller>,
     regex_ptr: jlong,
     string_ptr: jlong,
     byte_offset: jint,
     match_begin_position: jboolean,
     match_begin_string: jboolean,
-) -> jintArray {
-    try_catch(|| {
+) -> JIntArray<'caller> {
+    env.with_env(|env| {
         match_pattern(
-            &env,
+            env,
             regex_ptr,
             string_ptr,
             byte_offset,
@@ -103,40 +100,39 @@ pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_match(
             match_begin_string,
         )
     })
-    .propagate_exception(env)
-    .unwrap_or(ptr::null_mut())
+    .resolve::<ThrowMapped>()
 }
 
 #[no_mangle]
-pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_createString(
-    mut env: JNIEnv,
-    _: JClass,
-    utf8: jbyteArray,
+pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_createString<'caller>(
+    mut env: EnvUnowned<'caller>,
+    _: JClass<'caller>,
+    utf8: JByteArray<'caller>,
 ) -> jlong {
-    // This is the only place where we can not use try_catch(), because &mut JNIEnv can not cross FFI boundary
-    create_string(&mut env, utf8)
-        .propagate_exception(env)
-        .unwrap_or_default()
+    env.with_env(|env| create_string(env, &utf8))
+        .resolve::<ThrowMapped>()
 }
 
 #[no_mangle]
-pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_freeString(
-    env: JNIEnv,
-    _: JClass,
+pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_freeString<'caller>(
+    mut env: EnvUnowned<'caller>,
+    _: JClass<'caller>,
     ptr: jlong,
 ) {
     // Be careful to restore the owned type from the pointer
-    try_catch(|| free::<String>(ptr)).propagate_exception(env);
+    env.with_env(|_| free::<String>(ptr))
+        .resolve::<ThrowMapped>()
 }
 
 #[no_mangle]
-pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_freeRegex(
-    env: JNIEnv,
-    _: JClass,
+pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_freeRegex<'caller>(
+    mut env: EnvUnowned<'caller>,
+    _: JClass<'caller>,
     ptr: jlong,
 ) {
     // Be careful to restore the owned type from the pointer
-    try_catch(|| free::<Regex>(ptr)).propagate_exception(env);
+    env.with_env(|_| free::<Regex>(ptr))
+        .resolve::<ThrowMapped>()
 }
 
 fn free<T: 'static>(ptr: i64) -> Result<()> {
@@ -150,12 +146,11 @@ fn free<T: 'static>(ptr: i64) -> Result<()> {
     }
 }
 
-fn create_regex(env: &JNIEnv, pattern: jbyteArray) -> Result<jlong> {
+fn create_regex(env: &Env, pattern: &JByteArray) -> Result<jlong> {
     if pattern.is_null() {
         return Ok(0);
     }
-    let p = unsafe { JByteArray::from_raw(pattern) };
-    let byte_array: Vec<u8> = env.convert_byte_array(p)?;
+    let byte_array: Vec<u8> = env.convert_byte_array(pattern)?;
     // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createRegex, matching
     // the FFM binding, which hands the bytes to oniguruma without validating either. The bytes
     // go straight through to onig_new; nothing on the Rust side inspects them as text.
@@ -168,14 +163,14 @@ fn create_regex(env: &JNIEnv, pattern: jbyteArray) -> Result<jlong> {
     Ok(Box::into_raw(Box::<Regex>::new(regex)) as jlong)
 }
 
-fn match_pattern(
-    env: &JNIEnv,
+fn match_pattern<'local>(
+    env: &mut Env<'local>,
     regex_ptr: jlong,
     string_ptr: jlong,
     byte_offset: jint,
     match_begin_position: jboolean,
     match_begin_string: jboolean,
-) -> Result<jintArray> {
+) -> Result<JIntArray<'local>> {
     // Creating a null reference is UB even if it is not used
     if regex_ptr == 0 || string_ptr == 0 {
         return Err(Error::NullPatternOrString);
@@ -228,22 +223,22 @@ fn match_pattern(
                     offsets.push(s);
                     offsets.push(e);
                 }
-                Ok(create_jni_int_array(env, offsets.as_slice())?.into_raw())
+                create_jni_int_array(env, offsets.as_slice())
             })
         } else {
-            Ok(ptr::null_mut())
+            // A null array reference is how a mismatch is reported to Java.
+            Ok(JIntArray::null())
         }
     })
 }
 
-fn create_string(env: &mut JNIEnv, utf8: jbyteArray) -> Result<jlong> {
+fn create_string(env: &Env, utf8: &JByteArray) -> Result<jlong> {
     if utf8.is_null() {
         Result::<jlong>::Ok(0)
     } else {
         unsafe {
-            let p = JByteArray::from_raw(utf8);
             // Critical: pins the Java heap object without copying (GC is suspended for duration).
-            let elements = env.get_array_elements_critical(&p, ReleaseMode::NoCopyBack)?;
+            let elements = utf8.get_elements_critical(env, ReleaseMode::NoCopyBack)?;
             let slice = slice::from_raw_parts(elements.as_ptr() as *const u8, elements.len());
             // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createString,
             // matching the FFM binding, which copies the bytes into native memory without
@@ -257,55 +252,83 @@ fn create_string(env: &mut JNIEnv, utf8: jbyteArray) -> Result<jlong> {
     }
 }
 
-fn create_jni_int_array<'a>(env: &JNIEnv<'a>, input: &[i32]) -> Result<JPrimitiveArray<'a, i32>> {
-    let array = env.new_int_array(input.len() as i32)?;
-    env.set_int_array_region(&array, 0, input)?;
+fn create_jni_int_array<'local>(env: &mut Env<'local>, input: &[i32]) -> Result<JIntArray<'local>> {
+    let array = JIntArray::new(env, input.len())?;
+    array.set_region(env, 0, input)?;
     Ok(array)
 }
 
-trait ToJavaException<T> {
-    fn propagate_exception(self, env: JNIEnv) -> Option<T>;
-}
+/// Turns native method failures into Java exceptions.
+///
+/// `EnvUnowned::with_env` already wraps the closure in a `catch_unwind`, so a panic arrives here
+/// as [`ErrorPolicy::on_panic`] instead of having to be caught by hand.
+struct ThrowMapped;
 
-impl<T> ToJavaException<T> for Result<T> {
-    fn propagate_exception(self, mut env: JNIEnv) -> Option<T> {
-        match self {
-            Ok(r) => Some(r),
-            Err(error) => {
-                if !env.exception_check().unwrap() {
-                    // Only throw if there is no pending exception yet.
-                    match &error {
-                        // Caller errors surface as IllegalArgumentException, matching the FFM
-                        // binding. This path is rare enough that the class lookup is fine.
-                        Error::ByteOffsetOutOfRange { .. } => {
-                            let class = env.find_class("java/lang/IllegalArgumentException").unwrap();
-                            env.throw_new(class, error.to_string()).unwrap();
-                        }
-                        // Use the cached GlobalRef to avoid a class lookup on every throw.
-                        _ => match RUNTIME_EXCEPTION_CLASS.get() {
-                            Some(cls) => env.throw_new(cls, error.to_string()).unwrap(),
-                            None => {
-                                let class = env.find_class("java/lang/RuntimeException").unwrap();
-                                env.throw_new(class, error.to_string()).unwrap();
-                            }
-                        },
-                    }
+impl<T: Default> ErrorPolicy<T, Error> for ThrowMapped {
+    type Captures<'unowned_env_local: 'native_method, 'native_method> = ();
+
+    fn on_error<'unowned_env_local: 'native_method, 'native_method>(
+        env: &mut Env<'unowned_env_local>,
+        _captures: &mut Self::Captures<'unowned_env_local, 'native_method>,
+        error: Error,
+    ) -> jni::errors::Result<T> {
+        // Only throw if there is no pending exception yet.
+        if !env.exception_check() {
+            let message = JNIString::from(error.to_string());
+            match error {
+                // Caller errors surface as IllegalArgumentException, matching the FFM binding.
+                // This path is rare enough that the class lookup is fine.
+                Error::ByteOffsetOutOfRange { .. } => {
+                    let _ = env.throw_new(jni_str!("java/lang/IllegalArgumentException"), &message);
                 }
-                None
+                _ => throw_runtime_exception(env, &message),
             }
         }
+        Ok(T::default())
+    }
+
+    fn on_panic<'unowned_env_local: 'native_method, 'native_method>(
+        env: &mut Env<'unowned_env_local>,
+        _captures: &mut Self::Captures<'unowned_env_local, 'native_method>,
+        payload: Box<dyn Any + Send + 'static>,
+    ) -> jni::errors::Result<T> {
+        if !env.exception_check() {
+            let message =
+                JNIString::from(format!("Panic happened: {}", describe_panic(&*payload)));
+            throw_runtime_exception(env, &message);
+        }
+        Ok(T::default())
     }
 }
 
-// Wraps all panics into Result with a string description of a problem
-fn try_catch<T>(f: impl Fn() -> Result<T> + RefUnwindSafe) -> Result<T> {
-    catch_unwind(&f).map_err(downcast_error)?
+fn throw_runtime_exception(env: &mut Env, message: &JNIString) {
+    // Use the cached Global to avoid a class lookup on every throw. The string descriptor of the
+    // fallback resolves to RuntimeException as well, so both paths throw the same class.
+    let class = runtime_exception_class(env);
+    let _ = match class {
+        Ok(class) => env.throw_new(class, message),
+        Err(_) => env.throw_new(jni_str!("java/lang/RuntimeException"), message),
+    };
 }
 
-fn downcast_error(e: Box<dyn Any + Send>) -> Error {
-    if let Some(description) = e.downcast_ref::<String>() {
-        Error::Panic(description.to_string())
+fn runtime_exception_class(env: &mut Env) -> jni::errors::Result<&'static Global<JClass<'static>>> {
+    if let Some(class) = RUNTIME_EXCEPTION_CLASS.get() {
+        return Ok(class);
+    }
+    let class = env.find_class(jni_str!("java/lang/RuntimeException"))?;
+    // A racing thread may win the set(); the loser's Global is simply dropped.
+    let _ = RUNTIME_EXCEPTION_CLASS.set(env.new_global_ref(&class)?);
+    Ok(RUNTIME_EXCEPTION_CLASS
+        .get()
+        .expect("cache was just populated"))
+}
+
+fn describe_panic(payload: &(dyn Any + Send + 'static)) -> String {
+    if let Some(description) = payload.downcast_ref::<String>() {
+        description.clone()
+    } else if let Some(description) = payload.downcast_ref::<&'static str>() {
+        (*description).to_string()
     } else {
-        Error::Panic("Unknown".to_string())
+        "Unknown".to_string()
     }
 }

--- a/oniguruma-jni/native/src/lib.rs
+++ b/oniguruma-jni/native/src/lib.rs
@@ -190,10 +190,11 @@ fn match_pattern<'local>(
 
     let mut options = SearchOptions::SEARCH_OPTION_NONE;
     // `SearchOptions` has no named constants for these two, so they go in as raw bits.
-    if match_begin_position == 0 {
+    // Note that `jboolean` is a `bool` since jni-sys 0.4, not a `u8`.
+    if !match_begin_position {
         options |= SearchOptions::from_bits_retain(ONIG_OPTION_NOT_BEGIN_POSITION);
     }
-    if match_begin_string == 0 {
+    if !match_begin_string {
         options |= SearchOptions::from_bits_retain(ONIG_OPTION_NOT_BEGIN_STRING);
     }
 


### PR DESCRIPTION
Supersedes #79, which could not build. Dependabot bumped only `Cargo.toml`/`Cargo.lock`, and jni 0.22 needs both a newer toolchain and source changes.

## Why #79 failed

Two independent reasons:

1. **Toolchain too old.** jni 0.22.4 declares `rust-version = "1.85.0"` and `edition = "2024"`; the repo pinned 1.84.1, so cargo refuses the dependency before compiling any of our code. That is what actually failed in CI — all three `build-native-*` jobs died in 60-90s while every `oniguruma-ffm` job stayed green.
2. **The 0.22 API rewrite.** Bumping the toolchain alone just moves the failure into `native/src/lib.rs`.

## What's here

* `rust-toolchain` and `RUST_VERSION` in `build.yaml` / `test.yaml` / `benchmarks.yaml`: 1.84.1 -> 1.85.0. That is jni 0.22.4's exact MSRV; the new transitive deps need no more (`simd_cesu8` 1.2.0 -> 1.85.0, `jni-sys` 0.4.1 -> 1.76.0, `windows-link` 0.2.1 -> 1.71).
* `Cargo.toml` / `Cargo.lock` taken verbatim from the dependabot branch.
* `native/src/lib.rs` ported:
  * every entry point takes `EnvUnowned<'caller>` and runs its body in `with_env(...).resolve::<ThrowMapped>()`;
  * `ThrowMapped` is an `ErrorPolicy` replacing `ToJavaException`, `try_catch` and `downcast_error` — `with_env` already wraps the closure in a `catch_unwind` and routes panics to `on_panic`;
  * `GlobalRef` -> `Global<JClass<'static>>`; arrays move to `JIntArray::new` / `set_region` / `get_elements_critical`;
  * `match` returns `JIntArray<'caller>` rather than a raw `jintArray` (identical ABI; `resolve` requires `T: Default`, which raw pointers don't implement);
  * `jboolean` is a `bool` since jni-sys 0.4, so the two flag checks are `!flag` instead of `flag == 0`.

Behaviour is preserved: same exception classes (`IllegalArgumentException` for an out-of-range `byteOffset`, `RuntimeException` otherwise), same `"Panic happened: ..."` message, same pending-exception check, null array still signals a mismatch.

Three differences worth review attention:

* the RuntimeException class cache is filled on the first throw instead of in `JNI_OnLoad` — 0.22 offers no way to borrow an `Env` during library load;
* `JNI_OnLoad` no longer touches JNI at all (jni self-initializes on the first `with_env`) and only reports `JNI_VERSION_1_8`;
* `createString` gains panic protection it did not have before — the old code could not wrap it because `&mut JNIEnv` could not cross the FFI boundary.

## Verification

CI is green: the native library builds on Linux, macOS and Windows, and the `oniguruma-jni` test suite passes on all three platforms, so the port is exercised at runtime and not merely compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)