### PR TITLE
Copy the array with GetByteArrayRegion in createString

### DIFF
--- a/oniguruma-jni/native/src/lib.rs
+++ b/oniguruma-jni/native/src/lib.rs
@@ -18,16 +18,16 @@
 use jni::{
     errors::ErrorPolicy,
     jni_str,
-    objects::{Global, JByteArray, JClass, JIntArray, ReleaseMode},
+    objects::{Global, JByteArray, JClass, JIntArray},
     refs::Reference,
     strings::JNIString,
-    sys::{jboolean, jint, jlong},
+    sys::{jboolean, jint, jlong, jsize},
     Env, EnvUnowned,
 };
 use onig::Regex;
 use onig::{RegexOptions, Region, SearchOptions, Syntax};
 use onig_sys::{ONIG_OPTION_NOT_BEGIN_POSITION, ONIG_OPTION_NOT_BEGIN_STRING};
-use std::{any::Any, cell::RefCell, ffi::c_void, slice, str, sync::OnceLock};
+use std::{any::Any, cell::RefCell, ffi::c_void, str, sync::OnceLock};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -237,17 +237,33 @@ fn create_string(env: &Env, utf8: &JByteArray) -> Result<jlong> {
     if utf8.is_null() {
         Result::<jlong>::Ok(0)
     } else {
+        let len = utf8.len(env)?;
+        let mut bytes: Vec<u8> = Vec::with_capacity(len);
         unsafe {
-            // Critical: pins the Java heap object without copying (GC is suspended for duration).
-            let elements = utf8.get_elements_critical(env, ReleaseMode::NoCopyBack)?;
-            let slice = slice::from_raw_parts(elements.as_ptr() as *const u8, elements.len());
+            // GetByteArrayRegion copies straight into the Vec's spare capacity. Compared to
+            // GetPrimitiveArrayCritical this needs no critical section (nothing pins the Java
+            // heap, so the GC is never blocked) and one fewer JNI transition. Called through the
+            // raw vtable because JByteArray::get_region wants an initialized &mut [jbyte] (a
+            // zeroing pass the copy would immediately overwrite) and follows up with an
+            // ExceptionCheck call that is pointless here: the only exception this JNI function
+            // can raise is ArrayIndexOutOfBounds, and [0, len) is exact by construction since
+            // Java arrays cannot resize after GetArrayLength.
+            let raw_env = env.get_raw();
+            let interface = *raw_env;
+            ((*interface).v1_1.GetByteArrayRegion)(
+                raw_env,
+                utf8.as_raw(),
+                0,
+                len as jsize,
+                bytes.as_mut_ptr().cast(),
+            );
+            bytes.set_len(len);
             // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createString,
             // matching the FFM binding, which copies the bytes into native memory without
             // validating either. The bytes go straight through to onig_search; nothing on the
             // Rust side inspects them as text. Skipping validation keeps createString a single
             // copy, which is most of its cost for large texts.
-            let str = String::from_utf8_unchecked(slice.to_vec());
-            drop(elements); // Release critical section before any further JNI calls.
+            let str = String::from_utf8_unchecked(bytes);
             Ok(Box::into_raw(Box::<String>::new(str)) as jlong)
         }
     }


### PR DESCRIPTION
The buffer for the copy was allocated by slice::to_vec between GetPrimitiveArrayCritical and ReleasePrimitiveArrayCritical, while the GC is suspended. The JNI spec forbids anything that can block inside a critical section, and a malloc can.

Instead of shrinking the critical section, drop it entirely: reserve the destination Vec up front and let GetByteArrayRegion copy straight into its spare capacity. Nothing pins the Java heap anymore, and the call count per createString goes from three JNI transitions (GetArrayLength inside the jni crate's critical wrapper, plus the Get/Release pair) to two (GetArrayLength + GetByteArrayRegion). The region call goes through the raw vtable because the safe wrapper demands an initialized buffer (a zeroing pass the copy would immediately overwrite) and follows up with an ExceptionCheck that is pointless here: the only exception GetByteArrayRegion can raise is ArrayIndexOutOfBounds, and [0, len) is exact by construction.

On the jni 0.22 API the length comes from JByteArray::len, and the vtable entry is reached through the versioned union as (*interface).v1_1.GetByteArrayRegion, where it is a plain fn pointer rather than an Option. Panic protection is no longer part of this change: EnvUnowned::with_env already wraps every entry point.