### PR TITLE
Call the array JNI functions through the raw vtable

### DIFF
--- a/oniguruma-jni/native/src/lib.rs
+++ b/oniguruma-jni/native/src/lib.rs
@@ -21,7 +21,7 @@ use jni::{
     objects::{Global, JByteArray, JClass, JIntArray},
     refs::Reference,
     strings::JNIString,
-    sys::{jboolean, jint, jlong, jsize},
+    sys::{jboolean, jbyteArray, jint, jintArray, jlong, jsize},
     Env, EnvUnowned,
 };
 use onig::Regex;
@@ -150,7 +150,8 @@ fn create_regex(env: &Env, pattern: &JByteArray) -> Result<jlong> {
     if pattern.is_null() {
         return Ok(0);
     }
-    let byte_array: Vec<u8> = env.convert_byte_array(pattern)?;
+    // SAFETY: `pattern` is a non-null `byte[]` reference the JVM just handed us.
+    let byte_array = unsafe { copy_byte_array(env.get_raw(), pattern.as_raw()) };
     // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createRegex, matching
     // the FFM binding, which hands the bytes to oniguruma without validating either. The bytes
     // go straight through to onig_new; nothing on the Rust side inspects them as text.
@@ -164,7 +165,7 @@ fn create_regex(env: &Env, pattern: &JByteArray) -> Result<jlong> {
 }
 
 fn match_pattern<'local>(
-    env: &mut Env<'local>,
+    env: &Env<'local>,
     regex_ptr: jlong,
     string_ptr: jlong,
     byte_offset: jint,
@@ -224,7 +225,7 @@ fn match_pattern<'local>(
                     offsets.push(s);
                     offsets.push(e);
                 }
-                create_jni_int_array(env, offsets.as_slice())
+                Ok(create_jni_int_array(env, offsets.as_slice()))
             })
         } else {
             // A null array reference is how a mismatch is reported to Java.
@@ -237,42 +238,73 @@ fn create_string(env: &Env, utf8: &JByteArray) -> Result<jlong> {
     if utf8.is_null() {
         Result::<jlong>::Ok(0)
     } else {
-        let len = utf8.len(env)?;
-        let mut bytes: Vec<u8> = Vec::with_capacity(len);
-        unsafe {
-            // GetByteArrayRegion copies straight into the Vec's spare capacity. Compared to
-            // GetPrimitiveArrayCritical this needs no critical section (nothing pins the Java
-            // heap, so the GC is never blocked) and one fewer JNI transition. Called through the
-            // raw vtable because JByteArray::get_region wants an initialized &mut [jbyte] (a
-            // zeroing pass the copy would immediately overwrite) and follows up with an
-            // ExceptionCheck call that is pointless here: the only exception this JNI function
-            // can raise is ArrayIndexOutOfBounds, and [0, len) is exact by construction since
-            // Java arrays cannot resize after GetArrayLength.
-            let raw_env = env.get_raw();
-            let interface = *raw_env;
-            ((*interface).v1_1.GetByteArrayRegion)(
-                raw_env,
-                utf8.as_raw(),
-                0,
-                len as jsize,
-                bytes.as_mut_ptr().cast(),
-            );
-            bytes.set_len(len);
-            // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createString,
-            // matching the FFM binding, which copies the bytes into native memory without
-            // validating either. The bytes go straight through to onig_search; nothing on the
-            // Rust side inspects them as text. Skipping validation keeps createString a single
-            // copy, which is most of its cost for large texts.
-            let str = String::from_utf8_unchecked(bytes);
-            Ok(Box::into_raw(Box::<String>::new(str)) as jlong)
-        }
+        // SAFETY: `utf8` is a non-null `byte[]` reference the JVM just handed us.
+        let bytes = unsafe { copy_byte_array(env.get_raw(), utf8.as_raw()) };
+        // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createString,
+        // matching the FFM binding, which copies the bytes into native memory without
+        // validating either. The bytes go straight through to onig_search; nothing on the
+        // Rust side inspects them as text. Skipping validation keeps createString a single
+        // copy, which is most of its cost for large texts.
+        let str = unsafe { String::from_utf8_unchecked(bytes) };
+        Ok(Box::into_raw(Box::<String>::new(str)) as jlong)
     }
 }
 
-fn create_jni_int_array<'local>(env: &mut Env<'local>, input: &[i32]) -> Result<JIntArray<'local>> {
-    let array = JIntArray::new(env, input.len())?;
-    array.set_region(env, 0, input)?;
-    Ok(array)
+/// Copies a Java `byte[]` into a fresh `Vec<u8>`.
+///
+/// Two JNI calls and no zeroing pass: `Vec::with_capacity` leaves the buffer uninitialized and
+/// `GetByteArrayRegion` copies straight into it. `Env::convert_byte_array` instead zeroes a
+/// `vec![0u8; len]` that the copy immediately overwrites, and wraps both JNI calls in
+/// `ExceptionCheck` calls (one before each, one after the region copy). Neither call can fail
+/// here: `GetArrayLength` has no failure mode, and `[0, len)` is exact by construction because a
+/// Java array cannot resize after `GetArrayLength` returned its length.
+///
+/// # Safety
+///
+/// `raw_env` must be the JNI environment of the calling thread and `array` a non-null local
+/// reference to a `byte[]`.
+unsafe fn copy_byte_array(raw_env: *mut jni::sys::JNIEnv, array: jbyteArray) -> Vec<u8> {
+    let interface = *raw_env;
+    let len = ((*interface).v1_1.GetArrayLength)(raw_env, array) as usize;
+    let mut bytes: Vec<u8> = Vec::with_capacity(len);
+    if len > 0 {
+        // Skipped when empty so the dangling pointer of a zero-capacity Vec never reaches JNI.
+        ((*interface).v1_1.GetByteArrayRegion)(
+            raw_env,
+            array,
+            0,
+            len as jsize,
+            bytes.as_mut_ptr().cast(),
+        );
+    }
+    bytes.set_len(len);
+    bytes
+}
+
+/// Creates a Java `int[]` holding `values`.
+///
+/// Returns null if `NewIntArray` fails, leaving the pending `OutOfMemoryError` for the JVM to
+/// see. `SetIntArrayRegion` cannot throw over `[0, len)` of an array just allocated with exactly
+/// that length, so both calls skip the `ExceptionCheck` pairs that `JIntArray::new` and
+/// `JPrimitiveArray::set_region` add, along with the `Env::assert_top` thread-local read.
+///
+/// # Safety
+///
+/// `raw_env` must be the JNI environment of the calling thread.
+unsafe fn new_int_array(raw_env: *mut jni::sys::JNIEnv, values: &[jint]) -> jintArray {
+    let interface = *raw_env;
+    let len = values.len() as jsize;
+    let array = ((*interface).v1_1.NewIntArray)(raw_env, len);
+    if !array.is_null() {
+        ((*interface).v1_1.SetIntArrayRegion)(raw_env, array, 0, len, values.as_ptr());
+    }
+    array
+}
+
+fn create_jni_int_array<'local>(env: &Env<'local>, input: &[jint]) -> JIntArray<'local> {
+    // SAFETY: `new_int_array` returns a fresh local reference to an `int[]` (or null), created in
+    // this thread's environment, which is exactly what `from_raw` requires.
+    unsafe { JIntArray::from_raw(env, new_int_array(env.get_raw(), input)) }
 }
 
 /// Turns native method failures into Java exceptions.

--- a/oniguruma-jni/native/src/lib.rs
+++ b/oniguruma-jni/native/src/lib.rs
@@ -11,14 +11,17 @@
 //! So, for example `java.lang.System::gc()` becomes `Java_java_lang_System_gc`.
 //!
 //! Since jni 0.22 the environment a native method receives is an `EnvUnowned`, which carries no
-//! JNI methods of its own; `EnvUnowned::with_env` upgrades it to a `&mut Env` for the duration of
-//! a closure and catches any panic. Errors and panics are turned into Java exceptions by the
-//! [`ThrowMapped`] error policy.
+//! JNI methods of its own. Upgrading it to an `Env` with `EnvUnowned::with_env` costs attach-guard
+//! bookkeeping on every call, and the safe `Env` wrappers wrap each JNI function in
+//! `ExceptionCheck` calls, which together cost more than the JNI work these methods do. So the
+//! bodies here call JNI through the raw vtable, guard against panics with [`try_catch`], and
+//! materialize an `Env` only to report a failure, in [`throw`], where the [`ThrowMapped`] error
+//! policy picks the exception class.
 
 use jni::{
     errors::ErrorPolicy,
     jni_str,
-    objects::{Global, JByteArray, JClass, JIntArray},
+    objects::{Global, JByteArray, JClass},
     refs::Reference,
     strings::JNIString,
     sys::{jboolean, jbyteArray, jint, jintArray, jlong, jsize},
@@ -27,7 +30,14 @@ use jni::{
 use onig::Regex;
 use onig::{RegexOptions, Region, SearchOptions, Syntax};
 use onig_sys::{ONIG_OPTION_NOT_BEGIN_POSITION, ONIG_OPTION_NOT_BEGIN_STRING};
-use std::{any::Any, cell::RefCell, ffi::c_void, str, sync::OnceLock};
+use std::{
+    any::Any,
+    cell::RefCell,
+    ffi::c_void,
+    panic::{catch_unwind, AssertUnwindSafe},
+    ptr, str,
+    sync::OnceLock,
+};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -66,6 +76,9 @@ enum Error {
     #[error("byteOffset {offset} out of range [0, {length}]")]
     ByteOffsetOutOfRange { offset: i32, length: usize },
 
+    #[error("Panic happened: {0}")]
+    Panic(String),
+
     #[error("Null Pointer")]
     NullPointer,
 }
@@ -76,8 +89,17 @@ pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_createRegex<'call
     _: JClass<'caller>,
     pattern: JByteArray<'caller>,
 ) -> jlong {
-    env.with_env(|env| create_regex(env, &pattern))
-        .resolve::<ThrowMapped>()
+    // SAFETY: the JVM guarantees this pointer is the calling thread's JNI environment for the
+    // duration of the call. The body reaches JNI only through the raw vtable, so it needs no
+    // `Env` and skips what `with_env` does on every call.
+    let raw_env = env.as_raw();
+    match try_catch(|| unsafe { create_regex(raw_env, &pattern) }) {
+        Ok(regex_ptr) => regex_ptr,
+        Err(error) => {
+            throw(&mut env, error);
+            0
+        }
+    }
 }
 
 #[no_mangle]
@@ -89,18 +111,26 @@ pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_match<'caller>(
     byte_offset: jint,
     match_begin_position: jboolean,
     match_begin_string: jboolean,
-) -> JIntArray<'caller> {
-    env.with_env(|env| {
+) -> jintArray {
+    // SAFETY: see the note in createRegex.
+    let raw_env = env.as_raw();
+    let matched = try_catch(|| unsafe {
         match_pattern(
-            env,
+            raw_env,
             regex_ptr,
             string_ptr,
             byte_offset,
             match_begin_position,
             match_begin_string,
         )
-    })
-    .resolve::<ThrowMapped>()
+    });
+    match matched {
+        Ok(offsets) => offsets,
+        Err(error) => {
+            throw(&mut env, error);
+            ptr::null_mut()
+        }
+    }
 }
 
 #[no_mangle]
@@ -109,8 +139,15 @@ pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_createString<'cal
     _: JClass<'caller>,
     utf8: JByteArray<'caller>,
 ) -> jlong {
-    env.with_env(|env| create_string(env, &utf8))
-        .resolve::<ThrowMapped>()
+    // SAFETY: see the note in createRegex.
+    let raw_env = env.as_raw();
+    match try_catch(|| unsafe { create_string(raw_env, &utf8) }) {
+        Ok(string_ptr) => string_ptr,
+        Err(error) => {
+            throw(&mut env, error);
+            0
+        }
+    }
 }
 
 #[no_mangle]
@@ -120,8 +157,9 @@ pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_freeString<'calle
     ptr: jlong,
 ) {
     // Be careful to restore the owned type from the pointer
-    env.with_env(|_| free::<String>(ptr))
-        .resolve::<ThrowMapped>()
+    if let Err(error) = try_catch(|| free::<String>(ptr)) {
+        throw(&mut env, error);
+    }
 }
 
 #[no_mangle]
@@ -131,8 +169,9 @@ pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_freeRegex<'caller
     ptr: jlong,
 ) {
     // Be careful to restore the owned type from the pointer
-    env.with_env(|_| free::<Regex>(ptr))
-        .resolve::<ThrowMapped>()
+    if let Err(error) = try_catch(|| free::<Regex>(ptr)) {
+        throw(&mut env, error);
+    }
 }
 
 fn free<T: 'static>(ptr: i64) -> Result<()> {
@@ -146,12 +185,14 @@ fn free<T: 'static>(ptr: i64) -> Result<()> {
     }
 }
 
-fn create_regex(env: &Env, pattern: &JByteArray) -> Result<jlong> {
+/// # Safety
+///
+/// `raw_env` must be the JNI environment of the calling thread.
+unsafe fn create_regex(raw_env: *mut jni::sys::JNIEnv, pattern: &JByteArray) -> Result<jlong> {
     if pattern.is_null() {
         return Ok(0);
     }
-    // SAFETY: `pattern` is a non-null `byte[]` reference the JVM just handed us.
-    let byte_array = unsafe { copy_byte_array(env.get_raw(), pattern.as_raw()) };
+    let byte_array = copy_byte_array(raw_env, pattern.as_raw());
     // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createRegex, matching
     // the FFM binding, which hands the bytes to oniguruma without validating either. The bytes
     // go straight through to onig_new; nothing on the Rust side inspects them as text.
@@ -164,14 +205,17 @@ fn create_regex(env: &Env, pattern: &JByteArray) -> Result<jlong> {
     Ok(Box::into_raw(Box::<Regex>::new(regex)) as jlong)
 }
 
-fn match_pattern<'local>(
-    env: &Env<'local>,
+/// # Safety
+///
+/// `raw_env` must be the JNI environment of the calling thread.
+unsafe fn match_pattern(
+    raw_env: *mut jni::sys::JNIEnv,
     regex_ptr: jlong,
     string_ptr: jlong,
     byte_offset: jint,
     match_begin_position: jboolean,
     match_begin_string: jboolean,
-) -> Result<JIntArray<'local>> {
+) -> Result<jintArray> {
     // Creating a null reference is UB even if it is not used
     if regex_ptr == 0 || string_ptr == 0 {
         return Err(Error::NullPatternOrString);
@@ -225,21 +269,23 @@ fn match_pattern<'local>(
                     offsets.push(s);
                     offsets.push(e);
                 }
-                Ok(create_jni_int_array(env, offsets.as_slice()))
+                Ok(new_int_array(raw_env, offsets.as_slice()))
             })
         } else {
             // A null array reference is how a mismatch is reported to Java.
-            Ok(JIntArray::null())
+            Ok(ptr::null_mut())
         }
     })
 }
 
-fn create_string(env: &Env, utf8: &JByteArray) -> Result<jlong> {
+/// # Safety
+///
+/// `raw_env` must be the JNI environment of the calling thread.
+unsafe fn create_string(raw_env: *mut jni::sys::JNIEnv, utf8: &JByteArray) -> Result<jlong> {
     if utf8.is_null() {
         Result::<jlong>::Ok(0)
     } else {
-        // SAFETY: `utf8` is a non-null `byte[]` reference the JVM just handed us.
-        let bytes = unsafe { copy_byte_array(env.get_raw(), utf8.as_raw()) };
+        let bytes = copy_byte_array(raw_env, utf8.as_raw());
         // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createString,
         // matching the FFM binding, which copies the bytes into native memory without
         // validating either. The bytes go straight through to onig_search; nothing on the
@@ -301,16 +347,38 @@ unsafe fn new_int_array(raw_env: *mut jni::sys::JNIEnv, values: &[jint]) -> jint
     array
 }
 
-fn create_jni_int_array<'local>(env: &Env<'local>, input: &[jint]) -> JIntArray<'local> {
-    // SAFETY: `new_int_array` returns a fresh local reference to an `int[]` (or null), created in
-    // this thread's environment, which is exactly what `from_raw` requires.
-    unsafe { JIntArray::from_raw(env, new_int_array(env.get_raw(), input)) }
+/// Runs a native method body, turning a panic into an [`Error`] rather than letting it unwind
+/// into the JVM, which would abort the process.
+///
+/// `EnvUnowned::with_env` also catches panics, but only as part of materializing an `Env`: it
+/// pushes and pops the attach-guard nesting level in thread-local storage, calls `get_java_vm`
+/// and builds an `EnvOutcome`, all of which cost more than the JNI work in these methods. The
+/// bodies here reach JNI through the raw vtable and need no `Env` at all unless they fail, so
+/// the `Env` is left to [`throw`] on the cold path.
+///
+/// `AssertUnwindSafe` is sound here because a panic leaves nothing observable behind: the only
+/// state the bodies share between calls is the thread-local `Region` and offsets buffer, whose
+/// `RefCell` guards are released while unwinding, and both are cleared before use on the next
+/// call.
+fn try_catch<T>(body: impl FnOnce() -> Result<T>) -> Result<T> {
+    catch_unwind(AssertUnwindSafe(body))
+        .unwrap_or_else(|payload| Err(Error::Panic(describe_panic(&*payload))))
+}
+
+/// Throws `error` as a Java exception.
+///
+/// This is the only path that needs a real `Env`, so it is the only one that pays for
+/// [`EnvUnowned::with_env`]. Handing the error to the closure lets [`ThrowMapped`] pick the
+/// exception class, exactly as it does for a failure inside `with_env` itself.
+fn throw(env: &mut EnvUnowned, error: Error) {
+    env.with_env(|_| Err::<(), Error>(error))
+        .resolve::<ThrowMapped>()
 }
 
 /// Turns native method failures into Java exceptions.
 ///
-/// `EnvUnowned::with_env` already wraps the closure in a `catch_unwind`, so a panic arrives here
-/// as [`ErrorPolicy::on_panic`] instead of having to be caught by hand.
+/// A panic in a native method body is caught by [`try_catch`] and arrives as [`Error::Panic`], so
+/// [`ErrorPolicy::on_panic`] only runs in the far rarer case of a panic inside [`throw`] itself.
 struct ThrowMapped;
 
 impl<T: Default> ErrorPolicy<T, Error> for ThrowMapped {


### PR DESCRIPTION
Recovers the performance the jni 0.22 port cost, and then some. Rebased onto main now that #82 has merged, so this is two commits.

## Why the port regressed

Converting the report on #89 from ops/ms to ns/op showed a *fixed* per-call cost rather than slower copying: `createString` +132.9 ns and `createStringLarge` +122.2 ns — nearly the same absolute delta for a ~10x larger payload — with `createRegex` +113.6 ns, `match` +48.3 ns, and `createRegexLarge` (353 µs of regex compilation) unchanged.

Three causes, all in jni 0.22 and all invisible at the call site:

1. **Exception checks around every safe wrapper.** `Env::exception_check()` is itself a vtable call; `jni_call_no_post_check_ex!` pre-checks and `jni_call_with_catch!` pre- *and* post-checks. That is 4 extra transitions per `match` (`JIntArray::new` + `set_region`) and 3 per `createRegex` (`convert_byte_array`), which also zeroes a `vec![0u8; len]` the copy immediately overwrites.
2. **Attach-guard bookkeeping per native call.** `with_env` → `AttachGuard::from_unowned` → `thread_guard_level_push` (thread-local read + write, plus `THREAD_ATTACHMENT`), `get_java_vm`, `Env` and `EnvOutcome` construction, all unwound again on drop — plus `Env::assert_top`, a live `assert_eq!`, on every local-ref-creating call.
3. **`AutoElementsCritical`'s drop path**, which built a second nested attach guard *inside* the critical section while the GC was suspended. #82 removed this and measured +63% on `createString`.

The toolchain bump in the same commit was **not** a factor: #93 runs the pre-migration crate on Rust 1.85.0 and reproduces the old figures (`createString` 15,123 vs 15,359 ops/ms, `match` 5,222 vs 5,172, `createRegex` 2,228 vs 2,235).

## This PR

* **`Call the array JNI functions through the raw vtable`** (cause 1) — `copy_byte_array` (`GetArrayLength` + `GetByteArrayRegion`, no zeroing pass) shared by `createString` and `createRegex`, and a raw `NewIntArray` + `SetIntArrayRegion` pair for the `match` result.
* **`Materialize an Env only when a native method fails`** (cause 2) — the bodies take `EnvUnowned::as_raw()`, a `try_catch` helper catches panics as before the port, and `with_env` survives only in `throw`. `match` returns a plain `jintArray` again, since `JIntArray` was only needed for `EnvOutcome::resolve`'s `T: Default` bound.

Each raw call keeps the safety argument #82 established: the length comes from `GetArrayLength` and the destination is a fresh array of exactly that size, so the region calls cannot throw. `NewIntArray` is the one call that can fail, and it reports that by returning null with a pending `OutOfMemoryError`, which is handed straight back to the JVM. Nothing on the happy path calls into jni-rs (`is_null` and `as_raw` are pointer reads), so the rule that jni-rs is initialized before use still holds — the error path goes through `with_env` first.

## Measured (ops/ms, two independent runs on this PR)

| Benchmark | pre-migration | main today | this PR | vs pre-migration |
| --- | ---: | ---: | ---: | ---: |
| `createString` | 15,359 | 8,035 | 24,244 / 24,204 | **+58%** |
| `match` | 5,172 | 3,976 | 5,634 / 5,778 | **+10%** |
| `createRegex` | 2,235 | 1,765 | 2,281 / 2,255 | **+2%** |
| `createRegexLarge` | 2.83 | 2.84 | 2.968 / 2.951 | +4% |
| `createStringLarge` | 1,203 | 1,160 | no significant change vs main | see below |

No significant regressions in either run. `createStringLarge` is the one benchmark not restored: it shows no significant change against main, and its spread across configurations (1,160–1,270) is comparable to the differences under discussion, so it is dominated by the copy itself and by run-to-run noise rather than by per-call overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)