### PR TITLE
DO NOT MERGE: control run for the 1.85.0 toolchain

### DIFF
--- a/oniguruma-jni/native/Cargo.lock
+++ b/oniguruma-jni/native/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,52 +47,25 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.22.4"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
+ "cesu8",
  "cfg-if",
  "combine",
- "jni-macros",
  "jni-sys",
  "log",
- "simd_cesu8",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.98",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.4.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.98",
-]
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "libc"
@@ -141,7 +120,7 @@ dependencies = [
  "jni",
  "onig",
  "onig_sys",
- "thiserror",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -169,15 +148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,32 +157,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "simd_cesu8"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "syn"
@@ -238,11 +186,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.19",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -278,14 +246,17 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "windows-link"
-version = "0.2.1"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
 
 [[package]]
 name = "windows-sys"
@@ -293,7 +264,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -302,15 +288,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -320,9 +312,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -338,9 +342,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -350,9 +366,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/oniguruma-jni/native/Cargo.toml
+++ b/oniguruma-jni/native/Cargo.toml
@@ -10,7 +10,7 @@ name = "oniguruma_jni"
 [dependencies]
 onig = { version = "6.5", default-features = false }
 onig_sys = { version = "69.9", default-features = false }
-jni = { version = "0.22.4" }
+jni = { version = "0.21.1" }
 thiserror = "2.0.11"
 
 [profile.release]

--- a/oniguruma-jni/native/src/lib.rs
+++ b/oniguruma-jni/native/src/lib.rs
@@ -9,38 +9,37 @@
 //! 3. the method name is separated from the class name with an underscore
 //!
 //! So, for example `java.lang.System::gc()` becomes `Java_java_lang_System_gc`.
-//!
-//! Since jni 0.22 the environment a native method receives is an `EnvUnowned`, which carries no
-//! JNI methods of its own; `EnvUnowned::with_env` upgrades it to a `&mut Env` for the duration of
-//! a closure and catches any panic. Errors and panics are turned into Java exceptions by the
-//! [`ThrowMapped`] error policy.
 
 use jni::{
-    errors::ErrorPolicy,
-    jni_str,
-    objects::{Global, JByteArray, JClass, JIntArray},
-    refs::Reference,
-    strings::JNIString,
-    sys::{jboolean, jint, jlong, jsize},
-    Env, EnvUnowned,
+    objects::{GlobalRef, JByteArray, JClass, JPrimitiveArray, ReleaseMode},
+    sys::{jboolean, jbyteArray, jint, jintArray, jlong},
+    JavaVM, JNIEnv,
 };
 use onig::Regex;
 use onig::{RegexOptions, Region, SearchOptions, Syntax};
 use onig_sys::{ONIG_OPTION_NOT_BEGIN_POSITION, ONIG_OPTION_NOT_BEGIN_STRING};
-use std::{any::Any, cell::RefCell, ffi::c_void, str, sync::OnceLock};
+use std::{
+    any::Any,
+    cell::RefCell,
+    ffi::c_void,
+    panic::{catch_unwind, RefUnwindSafe},
+    ptr, slice,
+    str,
+    sync::OnceLock,
+};
 
 type Result<T> = std::result::Result<T, Error>;
 
-// Cache a Global to RuntimeException so the error path avoids a class lookup on every throw.
-// Filled on the first throw rather than in JNI_OnLoad: an `Env` can only be borrowed from a
-// thread attachment now, and there is no attachment to borrow from during library load.
-static RUNTIME_EXCEPTION_CLASS: OnceLock<Global<JClass<'static>>> = OnceLock::new();
+// Cache a GlobalRef to RuntimeException so the error path avoids a class lookup on every throw.
+static RUNTIME_EXCEPTION_CLASS: OnceLock<GlobalRef> = OnceLock::new();
 
 #[no_mangle]
 #[allow(non_snake_case)]
-pub extern "system" fn JNI_OnLoad(_: *mut jni::sys::JavaVM, _: *mut c_void) -> jint {
-    // jni initializes itself on the first `EnvUnowned::with_env`, so all this hook has to do is
-    // report the JNI version the library needs.
+pub unsafe extern "system" fn JNI_OnLoad(raw_vm: *mut jni::sys::JavaVM, _: *mut c_void) -> jint {
+    let vm = JavaVM::from_raw(raw_vm).unwrap();
+    let mut env: JNIEnv = vm.get_env().unwrap();
+    let cls = env.find_class("java/lang/RuntimeException").unwrap();
+    RUNTIME_EXCEPTION_CLASS.set(env.new_global_ref(cls).unwrap()).ok();
     jni::sys::JNI_VERSION_1_8
 }
 
@@ -66,33 +65,37 @@ enum Error {
     #[error("byteOffset {offset} out of range [0, {length}]")]
     ByteOffsetOutOfRange { offset: i32, length: usize },
 
+    #[error("Panic happened: {0}")]
+    Panic(String),
+
     #[error("Null Pointer")]
     NullPointer,
 }
 
 #[no_mangle]
-pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_createRegex<'caller>(
-    mut env: EnvUnowned<'caller>,
-    _: JClass<'caller>,
-    pattern: JByteArray<'caller>,
+pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_createRegex(
+    env: JNIEnv,
+    _: JClass,
+    pattern: jbyteArray,
 ) -> jlong {
-    env.with_env(|env| create_regex(env, &pattern))
-        .resolve::<ThrowMapped>()
+    try_catch(|| create_regex(&env, pattern))
+        .propagate_exception(env)
+        .unwrap_or_default()
 }
 
 #[no_mangle]
-pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_match<'caller>(
-    mut env: EnvUnowned<'caller>,
-    _: JClass<'caller>,
+pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_match(
+    env: JNIEnv,
+    _: JClass,
     regex_ptr: jlong,
     string_ptr: jlong,
     byte_offset: jint,
     match_begin_position: jboolean,
     match_begin_string: jboolean,
-) -> JIntArray<'caller> {
-    env.with_env(|env| {
+) -> jintArray {
+    try_catch(|| {
         match_pattern(
-            env,
+            &env,
             regex_ptr,
             string_ptr,
             byte_offset,
@@ -100,39 +103,40 @@ pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_match<'caller>(
             match_begin_string,
         )
     })
-    .resolve::<ThrowMapped>()
+    .propagate_exception(env)
+    .unwrap_or(ptr::null_mut())
 }
 
 #[no_mangle]
-pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_createString<'caller>(
-    mut env: EnvUnowned<'caller>,
-    _: JClass<'caller>,
-    utf8: JByteArray<'caller>,
+pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_createString(
+    mut env: JNIEnv,
+    _: JClass,
+    utf8: jbyteArray,
 ) -> jlong {
-    env.with_env(|env| create_string(env, &utf8))
-        .resolve::<ThrowMapped>()
+    // This is the only place where we can not use try_catch(), because &mut JNIEnv can not cross FFI boundary
+    create_string(&mut env, utf8)
+        .propagate_exception(env)
+        .unwrap_or_default()
 }
 
 #[no_mangle]
-pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_freeString<'caller>(
-    mut env: EnvUnowned<'caller>,
-    _: JClass<'caller>,
+pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_freeString(
+    env: JNIEnv,
+    _: JClass,
     ptr: jlong,
 ) {
     // Be careful to restore the owned type from the pointer
-    env.with_env(|_| free::<String>(ptr))
-        .resolve::<ThrowMapped>()
+    try_catch(|| free::<String>(ptr)).propagate_exception(env);
 }
 
 #[no_mangle]
-pub extern "system" fn Java_me_zolotov_oniguruma_jni_Oniguruma_freeRegex<'caller>(
-    mut env: EnvUnowned<'caller>,
-    _: JClass<'caller>,
+pub extern "C" fn Java_me_zolotov_oniguruma_jni_Oniguruma_freeRegex(
+    env: JNIEnv,
+    _: JClass,
     ptr: jlong,
 ) {
     // Be careful to restore the owned type from the pointer
-    env.with_env(|_| free::<Regex>(ptr))
-        .resolve::<ThrowMapped>()
+    try_catch(|| free::<Regex>(ptr)).propagate_exception(env);
 }
 
 fn free<T: 'static>(ptr: i64) -> Result<()> {
@@ -146,11 +150,12 @@ fn free<T: 'static>(ptr: i64) -> Result<()> {
     }
 }
 
-fn create_regex(env: &Env, pattern: &JByteArray) -> Result<jlong> {
+fn create_regex(env: &JNIEnv, pattern: jbyteArray) -> Result<jlong> {
     if pattern.is_null() {
         return Ok(0);
     }
-    let byte_array: Vec<u8> = env.convert_byte_array(pattern)?;
+    let p = unsafe { JByteArray::from_raw(pattern) };
+    let byte_array: Vec<u8> = env.convert_byte_array(p)?;
     // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createRegex, matching
     // the FFM binding, which hands the bytes to oniguruma without validating either. The bytes
     // go straight through to onig_new; nothing on the Rust side inspects them as text.
@@ -163,14 +168,14 @@ fn create_regex(env: &Env, pattern: &JByteArray) -> Result<jlong> {
     Ok(Box::into_raw(Box::<Regex>::new(regex)) as jlong)
 }
 
-fn match_pattern<'local>(
-    env: &mut Env<'local>,
+fn match_pattern(
+    env: &JNIEnv,
     regex_ptr: jlong,
     string_ptr: jlong,
     byte_offset: jint,
     match_begin_position: jboolean,
     match_begin_string: jboolean,
-) -> Result<JIntArray<'local>> {
+) -> Result<jintArray> {
     // Creating a null reference is UB even if it is not used
     if regex_ptr == 0 || string_ptr == 0 {
         return Err(Error::NullPatternOrString);
@@ -190,11 +195,10 @@ fn match_pattern<'local>(
 
     let mut options = SearchOptions::SEARCH_OPTION_NONE;
     // `SearchOptions` has no named constants for these two, so they go in as raw bits.
-    // Note that `jboolean` is a `bool` since jni-sys 0.4, not a `u8`.
-    if !match_begin_position {
+    if match_begin_position == 0 {
         options |= SearchOptions::from_bits_retain(ONIG_OPTION_NOT_BEGIN_POSITION);
     }
-    if !match_begin_string {
+    if match_begin_string == 0 {
         options |= SearchOptions::from_bits_retain(ONIG_OPTION_NOT_BEGIN_STRING);
     }
 
@@ -224,128 +228,84 @@ fn match_pattern<'local>(
                     offsets.push(s);
                     offsets.push(e);
                 }
-                create_jni_int_array(env, offsets.as_slice())
+                Ok(create_jni_int_array(env, offsets.as_slice())?.into_raw())
             })
         } else {
-            // A null array reference is how a mismatch is reported to Java.
-            Ok(JIntArray::null())
+            Ok(ptr::null_mut())
         }
     })
 }
 
-fn create_string(env: &Env, utf8: &JByteArray) -> Result<jlong> {
+fn create_string(env: &mut JNIEnv, utf8: jbyteArray) -> Result<jlong> {
     if utf8.is_null() {
         Result::<jlong>::Ok(0)
     } else {
-        let len = utf8.len(env)?;
-        let mut bytes: Vec<u8> = Vec::with_capacity(len);
         unsafe {
-            // GetByteArrayRegion copies straight into the Vec's spare capacity. Compared to
-            // GetPrimitiveArrayCritical this needs no critical section (nothing pins the Java
-            // heap, so the GC is never blocked) and one fewer JNI transition. Called through the
-            // raw vtable because JByteArray::get_region wants an initialized &mut [jbyte] (a
-            // zeroing pass the copy would immediately overwrite) and follows up with an
-            // ExceptionCheck call that is pointless here: the only exception this JNI function
-            // can raise is ArrayIndexOutOfBounds, and [0, len) is exact by construction since
-            // Java arrays cannot resize after GetArrayLength.
-            let raw_env = env.get_raw();
-            let interface = *raw_env;
-            ((*interface).v1_1.GetByteArrayRegion)(
-                raw_env,
-                utf8.as_raw(),
-                0,
-                len as jsize,
-                bytes.as_mut_ptr().cast(),
-            );
-            bytes.set_len(len);
+            let p = JByteArray::from_raw(utf8);
+            // Critical: pins the Java heap object without copying (GC is suspended for duration).
+            let elements = env.get_array_elements_critical(&p, ReleaseMode::NoCopyBack)?;
+            let slice = slice::from_raw_parts(elements.as_ptr() as *const u8, elements.len());
             // SAFETY: valid UTF-8 is the documented caller contract of Oniguruma.createString,
             // matching the FFM binding, which copies the bytes into native memory without
             // validating either. The bytes go straight through to onig_search; nothing on the
             // Rust side inspects them as text. Skipping validation keeps createString a single
             // copy, which is most of its cost for large texts.
-            let str = String::from_utf8_unchecked(bytes);
+            let str = String::from_utf8_unchecked(slice.to_vec());
+            drop(elements); // Release critical section before any further JNI calls.
             Ok(Box::into_raw(Box::<String>::new(str)) as jlong)
         }
     }
 }
 
-fn create_jni_int_array<'local>(env: &mut Env<'local>, input: &[i32]) -> Result<JIntArray<'local>> {
-    let array = JIntArray::new(env, input.len())?;
-    array.set_region(env, 0, input)?;
+fn create_jni_int_array<'a>(env: &JNIEnv<'a>, input: &[i32]) -> Result<JPrimitiveArray<'a, i32>> {
+    let array = env.new_int_array(input.len() as i32)?;
+    env.set_int_array_region(&array, 0, input)?;
     Ok(array)
 }
 
-/// Turns native method failures into Java exceptions.
-///
-/// `EnvUnowned::with_env` already wraps the closure in a `catch_unwind`, so a panic arrives here
-/// as [`ErrorPolicy::on_panic`] instead of having to be caught by hand.
-struct ThrowMapped;
+trait ToJavaException<T> {
+    fn propagate_exception(self, env: JNIEnv) -> Option<T>;
+}
 
-impl<T: Default> ErrorPolicy<T, Error> for ThrowMapped {
-    type Captures<'unowned_env_local: 'native_method, 'native_method> = ();
-
-    fn on_error<'unowned_env_local: 'native_method, 'native_method>(
-        env: &mut Env<'unowned_env_local>,
-        _captures: &mut Self::Captures<'unowned_env_local, 'native_method>,
-        error: Error,
-    ) -> jni::errors::Result<T> {
-        // Only throw if there is no pending exception yet.
-        if !env.exception_check() {
-            let message = JNIString::from(error.to_string());
-            match error {
-                // Caller errors surface as IllegalArgumentException, matching the FFM binding.
-                // This path is rare enough that the class lookup is fine.
-                Error::ByteOffsetOutOfRange { .. } => {
-                    let _ = env.throw_new(jni_str!("java/lang/IllegalArgumentException"), &message);
+impl<T> ToJavaException<T> for Result<T> {
+    fn propagate_exception(self, mut env: JNIEnv) -> Option<T> {
+        match self {
+            Ok(r) => Some(r),
+            Err(error) => {
+                if !env.exception_check().unwrap() {
+                    // Only throw if there is no pending exception yet.
+                    match &error {
+                        // Caller errors surface as IllegalArgumentException, matching the FFM
+                        // binding. This path is rare enough that the class lookup is fine.
+                        Error::ByteOffsetOutOfRange { .. } => {
+                            let class = env.find_class("java/lang/IllegalArgumentException").unwrap();
+                            env.throw_new(class, error.to_string()).unwrap();
+                        }
+                        // Use the cached GlobalRef to avoid a class lookup on every throw.
+                        _ => match RUNTIME_EXCEPTION_CLASS.get() {
+                            Some(cls) => env.throw_new(cls, error.to_string()).unwrap(),
+                            None => {
+                                let class = env.find_class("java/lang/RuntimeException").unwrap();
+                                env.throw_new(class, error.to_string()).unwrap();
+                            }
+                        },
+                    }
                 }
-                _ => throw_runtime_exception(env, &message),
+                None
             }
         }
-        Ok(T::default())
-    }
-
-    fn on_panic<'unowned_env_local: 'native_method, 'native_method>(
-        env: &mut Env<'unowned_env_local>,
-        _captures: &mut Self::Captures<'unowned_env_local, 'native_method>,
-        payload: Box<dyn Any + Send + 'static>,
-    ) -> jni::errors::Result<T> {
-        if !env.exception_check() {
-            let message =
-                JNIString::from(format!("Panic happened: {}", describe_panic(&*payload)));
-            throw_runtime_exception(env, &message);
-        }
-        Ok(T::default())
     }
 }
 
-fn throw_runtime_exception(env: &mut Env, message: &JNIString) {
-    // Use the cached Global to avoid a class lookup on every throw. The string descriptor of the
-    // fallback resolves to RuntimeException as well, so both paths throw the same class.
-    let class = runtime_exception_class(env);
-    let _ = match class {
-        Ok(class) => env.throw_new(class, message),
-        Err(_) => env.throw_new(jni_str!("java/lang/RuntimeException"), message),
-    };
+// Wraps all panics into Result with a string description of a problem
+fn try_catch<T>(f: impl Fn() -> Result<T> + RefUnwindSafe) -> Result<T> {
+    catch_unwind(&f).map_err(downcast_error)?
 }
 
-fn runtime_exception_class(env: &mut Env) -> jni::errors::Result<&'static Global<JClass<'static>>> {
-    if let Some(class) = RUNTIME_EXCEPTION_CLASS.get() {
-        return Ok(class);
-    }
-    let class = env.find_class(jni_str!("java/lang/RuntimeException"))?;
-    // A racing thread may win the set(); the loser's Global is simply dropped.
-    let _ = RUNTIME_EXCEPTION_CLASS.set(env.new_global_ref(&class)?);
-    Ok(RUNTIME_EXCEPTION_CLASS
-        .get()
-        .expect("cache was just populated"))
-}
-
-fn describe_panic(payload: &(dyn Any + Send + 'static)) -> String {
-    if let Some(description) = payload.downcast_ref::<String>() {
-        description.clone()
-    } else if let Some(description) = payload.downcast_ref::<&'static str>() {
-        (*description).to_string()
+fn downcast_error(e: Box<dyn Any + Send>) -> Error {
+    if let Some(description) = e.downcast_ref::<String>() {
+        Error::Panic(description.to_string())
     } else {
-        "Unknown".to_string()
+        Error::Panic("Unknown".to_string())
     }
 }


### PR DESCRIPTION
⚠️ **Not for merging.** This branch exists to produce a single benchmark run, then it should be closed.

## Why

Commit 41dddb1 changed two variables at once — Rust 1.84.1 → 1.85.0 *and* jni 0.21.1 → 0.22.4 — so nothing in the recorded benchmark history separates a compiler codegen effect from the library's per-call overhead. My analysis attributes the regression entirely to jni 0.22 (exception checks around every safe wrapper, attach-guard thread-local bookkeeping per native call, and the critical-section drop path), but that is inference from reading the jni sources, not measurement.

## What this is

The pre-migration crate exactly as of 27bf552 — `jni = 0.21.1`, its `Cargo.lock`, and the original `src/lib.rs` — on top of main's 1.85.0 toolchain. The toolchain is then the only difference from the old baseline.

## How to read the result

The report compares against `main`, so expect large "improvements"; ignore them. The number that matters is absolute:

* `createString` ≈ 15,359 ops/ms → the toolchain is exonerated, the regression is entirely jni 0.22.
* materially below that → codegen contributes and #92's approach only addresses part of the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)